### PR TITLE
Error hierarchy: DocaiError base class

### DIFF
--- a/docs/decisions/DECISIONS-SUMMARY.md
+++ b/docs/decisions/DECISIONS-SUMMARY.md
@@ -867,25 +867,31 @@ exits.
 
 ### Exception hierarchy
 
+Flat — all errors inherit directly from `DocaiError`. The workflow decides whether an error
+is fatal (re-raise as `PipelineError`, exit 2) or recoverable (log, mark file failed,
+continue, exit 1).
+
 ```
-DocaiError (base)
-├── PipelineError                    # fatal, stops execution
-│   ├── ConfigError                  # includes API key validation failure
-│   └── StateError
-└── ComponentError                   # recoverable, file-level failure
-    ├── DiscoveryError
-    ├── ExtractionError
-    ├── GraphError
-    └── GenerationError
+DocaiError (base)          # src/docai/errors.py
+├── PipelineError          # workflow/  — workflow decided this is a dealbreaker
+├── ConfigError            # cli/       — bad/missing config, before pipeline starts
+├── StateError             # state/     — .docai/ corrupt, locked, version mismatch
+├── LLMError               # llm/       — LLM interaction failure
+├── CoreError              # core/      — shared utility failure
+├── DiscoveryError         # discovery/
+├── ExtractionError        # extractor/
+├── GraphError             # graph/
+└── GenerationError        # generator/
 ```
 
-`LLMError` is internal to the `llm/` package. When LLM failures surface beyond `llm/`,
-the consuming component wraps them as its own `ComponentError` subclass, preserving the
-original via `__cause__`.
+All errors carry two fields: `code` and `message`. `__cause__` follows standard Python
+exception chaining.
 
-All `ComponentError` subclasses carry: `file_path`, `code` (machine-readable, e.g.
-`EXTRACTION_PARSE_FAILED`), `message`, and `__cause__`. `PipelineError` carries `code` and
-`message` but not `file_path`.
+- `message` — human-readable description of what went wrong
+- `code` — machine-readable identifier following the convention `COMPONENT_WHAT_HAPPENED`
+  (uppercase with underscores). Examples: `EXTRACTION_PARSE_FAILED`, `CONFIG_MISSING_API_KEY`,
+  `LLM_RATE_LIMIT`, `STATE_LOCKED`, `PIPELINE_NO_FILES`. Each component defines its own
+  codes alongside its error class.
 
 ### CLI exit codes
 

--- a/src/docai/errors.py
+++ b/src/docai/errors.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+
+class DocaiError(Exception):
+    """Base class for all docai errors."""
+
+    def __init__(self, message: str, code: str) -> None:
+        super().__init__(message)
+        self.message = message
+        self.code = code
+
+    def format_compact(self) -> str:
+        """Render the error chain as: [CODE] message → [CODE] message → ..."""
+        parts: list[str] = []
+        current: BaseException | None = self
+        while current is not None and isinstance(current, DocaiError):
+            parts.append(f"[{current.code}] {current.message}")
+            current = current.__cause__
+        return " → ".join(parts)

--- a/tests/test_core/test_errors.py
+++ b/tests/test_core/test_errors.py
@@ -1,0 +1,115 @@
+import pytest
+
+from docai.errors import DocaiError
+
+
+@pytest.mark.unit
+class TestDocaiErrorFields:
+    def test_has_message_field(self) -> None:
+        error = DocaiError(message="something went wrong", code="SOME_ERROR")
+        assert error.message == "something went wrong"
+
+    def test_has_code_field(self) -> None:
+        error = DocaiError(message="something went wrong", code="SOME_ERROR")
+        assert error.code == "SOME_ERROR"
+
+    def test_message_and_code_set_correctly(self) -> None:
+        error = DocaiError(message="rate limit exceeded", code="LLM_RATE_LIMIT")
+        assert error.message == "rate limit exceeded"
+        assert error.code == "LLM_RATE_LIMIT"
+
+    def test_cause_chain_accessible(self) -> None:
+        cause = DocaiError(message="root cause", code="ROOT_ERROR")
+        error = DocaiError(message="top error", code="TOP_ERROR")
+        error.__cause__ = cause
+        assert error.__cause__ is cause
+        assert error.__cause__.message == "root cause"
+
+
+@pytest.mark.unit
+class TestFormatCompact:
+    def test_single_error_no_chain(self) -> None:
+        error = DocaiError(
+            message="API key not found. Set GEMINI_API_KEY or add api_key to docai.toml.",
+            code="CONFIG_MISSING_API_KEY",
+        )
+        assert error.format_compact() == (
+            "[CONFIG_MISSING_API_KEY] API key not found. Set GEMINI_API_KEY or add api_key to docai.toml."
+        )
+
+    def test_single_error_state_locked(self) -> None:
+        error = DocaiError(
+            message="another docai process is already running (PID 48291).",
+            code="STATE_LOCKED",
+        )
+        assert error.format_compact() == (
+            "[STATE_LOCKED] another docai process is already running (PID 48291)."
+        )
+
+    def test_single_error_no_files(self) -> None:
+        error = DocaiError(
+            message="no processable files found. Check your .docaiignore or run docai list.",
+            code="PIPELINE_NO_FILES",
+        )
+        assert error.format_compact() == (
+            "[PIPELINE_NO_FILES] no processable files found. Check your .docaiignore or run docai list."
+        )
+
+    def test_single_error_permission_denied(self) -> None:
+        error = DocaiError(
+            message="cannot read src/secret.py — permission denied",
+            code="DISCOVERY_PERMISSION_DENIED",
+        )
+        assert error.format_compact() == (
+            "[DISCOVERY_PERMISSION_DENIED] cannot read src/secret.py — permission denied"
+        )
+
+    def test_two_level_chain(self) -> None:
+        root = DocaiError(
+            message="LLM validation failed after 3 retries",
+            code="LLM_VALIDATION_EXHAUSTED",
+        )
+        top = DocaiError(
+            message="failed to extract src/parser.py",
+            code="EXTRACTION_PARSE_FAILED",
+        )
+        top.__cause__ = root
+
+        assert top.format_compact() == (
+            "[EXTRACTION_PARSE_FAILED] failed to extract src/parser.py"
+            " → [LLM_VALIDATION_EXHAUSTED] LLM validation failed after 3 retries"
+        )
+
+    def test_three_level_chain(self) -> None:
+        root = DocaiError(
+            message="rate limit exceeded after 3 retries",
+            code="LLM_RATE_LIMIT",
+        )
+        mid = DocaiError(
+            message="failed to document src/parser.py",
+            code="GENERATION_FAILED",
+        )
+        top = DocaiError(
+            message="pipeline aborted",
+            code="PIPELINE_ABORTED",
+        )
+        mid.__cause__ = root
+        top.__cause__ = mid
+
+        assert top.format_compact() == (
+            "[PIPELINE_ABORTED] pipeline aborted"
+            " → [GENERATION_FAILED] failed to document src/parser.py"
+            " → [LLM_RATE_LIMIT] rate limit exceeded after 3 retries"
+        )
+
+    def test_chain_stops_at_non_docai_error(self) -> None:
+        raw = PermissionError("permission denied")
+        top = DocaiError(
+            message="cannot read src/secret.py — permission denied",
+            code="DISCOVERY_PERMISSION_DENIED",
+        )
+        top.__cause__ = raw
+
+        assert top.format_compact() == (
+            "[DISCOVERY_PERMISSION_DENIED] cannot read src/secret.py — permission denied"
+        )

--- a/tests/test_placeholder.py
+++ b/tests/test_placeholder.py
@@ -1,5 +1,0 @@
-# Placeholder — delete this file once real tests are added
-
-
-def test_placeholder() -> None:
-    pass


### PR DESCRIPTION
## Summary

- `src/docai/errors.py` — `DocaiError` base class with `code` and `message` fields
- `format_compact()` renders the error chain as `[CODE] message → [CODE] message → ...`, stopping at non-DocaiError causes
- Flat hierarchy: all component errors will inherit directly from `DocaiError`; each component defines its own subclass and error codes alongside its implementation
- Updated `DECISIONS-SUMMARY.md` with revised hierarchy and `COMPONENT_WHAT_HAPPENED` error code convention
- Removed placeholder test now that real tests exist

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)